### PR TITLE
Fixes bug in onCurrentLine and adds corresponding test

### DIFF
--- a/src/GameTree.js
+++ b/src/GameTree.js
@@ -257,7 +257,6 @@ class GameTree {
 
   onCurrentLine(id, currents) {
     for (let node of this.listNodesVertically(id, -1, {})) {
-      if (node.id === id) continue
       let {parentId} = node
 
       if (

--- a/tests/GameTree.test.js
+++ b/tests/GameTree.test.js
@@ -165,6 +165,7 @@ t.test('onCurrentLine method', t => {
   t.equal(tree.onCurrentLine(tree.root.id, {}), true)
   t.equal(tree.onCurrentLine(subChildId1, {[id1]: childId2}), false)
   t.equal(tree.onCurrentLine(subChildId1, {[id1]: childId3}), true)
+  t.equal(tree.onCurrentLine(childId1, {[id1]: childId2}), false)
 
   t.end()
 })


### PR DESCRIPTION
I found that the function `onCurrentLine` returns `true` as long as the given node's _parent_ is on the current line, even if the node is not a distinguished child of this parent.
I have removed the line that was causing the problem and added a corresponding test case.